### PR TITLE
feat(index): add newline-after-var rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const importNoUnresolved = require('./rule-options/import.no-unresolved');
 const importOrder = require('./rule-options/import.order');
+const paddingLineBetweenStatements = require('./rule-options/padding-line-between-statements');
 const prettierPrettier = require('./rule-options/prettier.prettier');
 const reactBooleanPropNaming = require('./rule-options/react.boolean-prop-naming');
 const reactJsxFilenameExtension = require('./rule-options/react.jsx-filename-extension');
@@ -34,6 +35,7 @@ module.exports = {
     'import/no-default-export': 2,
     'import/no-unresolved': [2, importNoUnresolved],
     'import/order': [2, importOrder],
+    'padding-line-between-statements': [2, ...paddingLineBetweenStatements],
     'no-console': 2,
     'no-undef': 2,
     'no-unreachable': 2,

--- a/rule-options/padding-line-between-statements.js
+++ b/rule-options/padding-line-between-statements.js
@@ -1,0 +1,8 @@
+module.exports = [
+  { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
+  {
+    blankLine: 'any',
+    prev: ['const', 'let', 'var'],
+    next: ['const', 'let', 'var'],
+  },
+];


### PR DESCRIPTION
### Why?

To enforce more consistent formatting and improve overall readability.

https://eslint.org/docs/rules/padding-line-between-statements

Good 👍 
```
function foo() {
    const a = 0;

    bar();
}

function foo() {
    const a = 0;
    const b = 0;

    bar();
}

function foo() {
    let a = 0;
    const b = 0;
    var c = 0;

    bar();
}
```
Bad 👎 
```
function foo() {
    const a = 0;
    bar();
}

function foo() {
    const a = 0;
    
    const b = 0;

    bar();
}

function foo() {
    let a = 0;

    const b = 0;

    var c = 0;

    bar();
}
```